### PR TITLE
Get icons with previews from any theme path

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ If you want to get lazyloading div or tag as a string, you may prefix functions 
 * `get_prev_page_id( $post_id )` Get ID of previous page. Defaults to current page.
 
 #### Misc
-* `get_icons_for_user( $show_preview = false )` Get list of icons which are available for user. Returns array of icons inside theme's `svg/foruser` directory.
+* `get_icons_for_user( $args)` Get list of icons which are available for user. Returns array of icons from defined theme directory (default `svg/foruser/`).
 * `wp_parse_args_dimensional( $a, $b )` Similar to wp_parse_args() just extended to work with multidimensional arrays.
 * `get_the_sentence_excerpt( $length, $excerpt )` Get excerpt with custom length of sentences. Defaults to three sentences and current post.
 * `get_primary_category( $post_id )` Get primary category for defined or current post.

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ If you want to get lazyloading div or tag as a string, you may prefix functions 
 * `get_prev_page_id( $post_id )` Get ID of previous page. Defaults to current page.
 
 #### Misc
-* `get_icons_for_user( $use_preview = false )` Get list of icons which are available for user. Returns array of icons inside theme's `svg/foruser` directory.
+* `get_icons_for_user( $show_preview = false )` Get list of icons which are available for user. Returns array of icons inside theme's `svg/foruser` directory.
 * `wp_parse_args_dimensional( $a, $b )` Similar to wp_parse_args() just extended to work with multidimensional arrays.
 * `get_the_sentence_excerpt( $length, $excerpt )` Get excerpt with custom length of sentences. Defaults to three sentences and current post.
 * `get_primary_category( $post_id )` Get primary category for defined or current post.

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ If you want to get lazyloading div or tag as a string, you may prefix functions 
 * `get_prev_page_id( $post_id )` Get ID of previous page. Defaults to current page.
 
 #### Misc
-* `get_icons_for_user()` Get list of icons which are available for user. Returns array of icons inside theme's `svg/foruser` directory.
+* `get_icons_for_user( $use_preview = false )` Get list of icons which are available for user. Returns array of icons inside theme's `svg/foruser` directory.
 * `wp_parse_args_dimensional( $a, $b )` Similar to wp_parse_args() just extended to work with multidimensional arrays.
 * `get_the_sentence_excerpt( $length, $excerpt )` Get excerpt with custom length of sentences. Defaults to three sentences and current post.
 * `get_primary_category( $post_id )` Get primary category for defined or current post.

--- a/functions/misc.php
+++ b/functions/misc.php
@@ -20,8 +20,8 @@ if ( ! function_exists( 'get_icons_for_user' ) ) {
    */
   function get_icons_for_user( $args = [] ) {
     $default_args = [
-      'show_preview' => false, // Shows icon preview, requires you have enabled Select2 in ACF Select field
-      'icon_path' => 'svg/foruser/', // Set icon path in theme directory
+      'show_preview' => false,
+      'icon_path' => '/svg/foruser/',
     ];
 
     $args = wp_parse_args( $args, $default_args );
@@ -38,7 +38,7 @@ if ( ! function_exists( 'get_icons_for_user' ) ) {
       // If using the ACF select2 improved UI, show preview icons
       if ( $args['show_preview'] ) {
         ob_start();
-        echo esc_html( ucfirst( $filename ) ) . '&nbsp;&nbsp;<br/><br/>';
+        echo esc_html( ucfirst( $filename ) );
         include get_theme_file_path( $args['icon_path'] . $raw_filename );
         $icons[ $raw_filename ] = ob_get_clean();
       } else {

--- a/functions/misc.php
+++ b/functions/misc.php
@@ -15,9 +15,10 @@ if ( ! function_exists( 'get_icons_for_user' ) ) {
    *  Get list of icons which are available for user.
    *
    *  @since  1.4.0
+   *  @param bool $show_preview Shows icon preview, requires you have enabled Select2 in ACF Select field.
    *  @return array  Array of icons available.
    */
-  function get_icons_for_user() {
+  function get_icons_for_user( $show_preview = false ) {
     $icons = [];
     $files = glob( get_template_directory() . '/svg/foruser/*.svg' );
 
@@ -27,7 +28,16 @@ if ( ! function_exists( 'get_icons_for_user' ) ) {
       $filename = strstr( $raw_filename, '.', true );
       $filename = str_replace( '-', ' ', $filename );
       $filename = str_replace( '_', ' ', $filename );
-      $icons[ $raw_filename ] = ucfirst( $filename );
+
+      // If using the ACF select2 improved UI, show preview icons
+      if ( $show_preview ) {
+        ob_start();
+        echo esc_html( ucfirst( $filename ) ) . '&nbsp;&nbsp;<br/><br/>';
+        include get_theme_file_path( '/svg/foruser/' . $raw_filename );
+        $icons[ $raw_filename ] = ob_get_clean();
+      } else {
+        $icons[ $raw_filename ] = ucfirst( $filename );
+      }
     }
 
     return $icons;

--- a/functions/misc.php
+++ b/functions/misc.php
@@ -15,12 +15,18 @@ if ( ! function_exists( 'get_icons_for_user' ) ) {
    *  Get list of icons which are available for user.
    *
    *  @since  1.4.0
-   *  @param bool $show_preview Shows icon preview, requires you have enabled Select2 in ACF Select field.
+   *  @param array $args Array of arguments.
    *  @return array  Array of icons available.
    */
-  function get_icons_for_user( $show_preview = false ) {
+  function get_icons_for_user( $args = [] ) {
+    $default_args = [
+      'show_preview' => false, // Shows icon preview, requires you have enabled Select2 in ACF Select field
+      'icon_path' => 'svg/foruser/', // Set icon path in theme directory
+    ];
+
+    $args = wp_parse_args( $args, $default_args );
     $icons = [];
-    $files = glob( get_template_directory() . '/svg/foruser/*.svg' );
+    $files = glob( get_template_directory() . '/' . $args['icon_path'] . '*.svg' );
 
     foreach ( $files as $file ) {
       $raw_filename = explode( '/', $file );
@@ -30,10 +36,10 @@ if ( ! function_exists( 'get_icons_for_user' ) ) {
       $filename = str_replace( '_', ' ', $filename );
 
       // If using the ACF select2 improved UI, show preview icons
-      if ( $show_preview ) {
+      if ( $args['show_preview'] ) {
         ob_start();
         echo esc_html( ucfirst( $filename ) ) . '&nbsp;&nbsp;<br/><br/>';
-        include get_theme_file_path( '/svg/foruser/' . $raw_filename );
+        include get_theme_file_path( $args['icon_path'] . $raw_filename );
         $icons[ $raw_filename ] = ob_get_clean();
       } else {
         $icons[ $raw_filename ] = ucfirst( $filename );


### PR DESCRIPTION
- Enables icon previews in acf select fields. Select2 must be enabled on the ACF field settings for previews to work, although this has a ugly, but working fallback too. Previews are disabled by default.
- User can define the theme path icons are loaded from, default being `svg/foruser/` 

Usage example:

```
add_filter( 'acf/load_field/type=select', 'acf_dynamic_select_for_icon' );
function acf_dynamic_select_for_icon( $field ) {
  if ( ! function_exists( 'get_icons_for_user' ) ) {
    return $field;
  }

  if ( false === strpos( $field['name'], 'icon_svg' ) ) {
    return $field;
  }

  // add icons from "svg/foruser" directory.
  $args = [
    'show_preview' => $field['ui'],
    'icon_path' => 'svg/foruser/',
  ];

  $field['choices'] = get_icons_for_user( $args );

  return $field;
}
```
