### PR TITLE
Make us of new wp_get_environment_type function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Changed
 - Allow REST API users endpoints if user is logged in and can edit_posts
 - Get icons with previews from any theme path
+- Changed `WP_ENV` checks to new core function `wp_get_environment_type` introduced in 5.5
 
 ### Fixed
 - Escape outputting localization functions ask_e, asv_e and pll_e return

--- a/air-helper.php
+++ b/air-helper.php
@@ -6,7 +6,7 @@
  * Version: 2.5.0
  * Author: Digitoimisto Dude Oy, Timi Wahalahti
  * Author URI: https://www.dude.fi
- * Requires at least: 5.0
+ * Requires at least: 5.5
  * Tested up to: 5.5
  * License: GPL-3.0+
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html

--- a/inc/admin/adminbar.php
+++ b/inc/admin/adminbar.php
@@ -5,7 +5,7 @@
  * @Author: Timi Wahalahti
  * @Date:   2020-01-10 16:14:34
  * @Last Modified by:   Timi Wahalahti
- * @Last Modified time: 2020-02-20 10:51:38
+ * @Last Modified time: 2021-02-19 14:28:58
  *
  * @package air-helper
  */
@@ -53,14 +53,12 @@ function air_helper_helper_remove_admin_bar_links() {
 add_action( 'admin_bar_menu', 'air_helper_adminbar_show_env', 999 );
 function air_helper_adminbar_show_env( $wp_admin_bar ) {
   // Default to production env
-  $env = esc_attr__( 'production', 'air-helper' );
+  $env = wp_get_environment_type();
   $class = 'air-helper-env-prod';
 
-  if ( getenv( 'WP_ENV' ) === 'staging' ) {
-    $env = esc_attr__( 'staging', 'air-helper' );
+  if ( wp_get_environment_type() === 'staging' ) {
     $class = 'air-helper-env-stage';
-  } else if ( getenv( 'WP_ENV' ) === 'development' ) {
-    $env = esc_attr__( 'development', 'air-helper' );
+  } else if ( wp_get_environment_type() === 'development' ) {
     $env .= ' (DB ' . getenv( 'DB_HOST' ) . ')'; // On dev, show database
     $class = 'air-helper-env-dev';
   }

--- a/inc/mail.php
+++ b/inc/mail.php
@@ -5,7 +5,7 @@
  * @Author: Timi Wahalahti
  * @Date:   2020-01-10 16:07:14
  * @Last Modified by:   Timi Wahalahti
- * @Last Modified time: 2020-02-13 15:26:03
+ * @Last Modified time: 2021-02-19 14:26:45
  *
  * @package air-helper
  */
@@ -17,12 +17,12 @@
  *
  *  @since  0.1.0
  */
-if ( getenv( 'WP_ENV' ) === 'development' ) {
+if ( wp_get_environment_type() === 'development' ) {
   add_filter( 'wp_mail', 'air_helper_helper_force_mail_to' );
 }
 
 // Turn off by using `remove_filter( 'wp_mail', 'air_helper_helper_force_mail_to' )`
-if ( getenv( 'WP_ENV' ) === 'staging' ) {
+if ( wp_get_environment_type() === 'staging' ) {
   add_filter( 'wp_mail', 'air_helper_helper_force_mail_to' );
   add_filter( 'wp_mail_from', 'air_helper_staging_wp_mail_from' );
 }
@@ -40,7 +40,7 @@ if ( getenv( 'WP_ENV' ) === 'staging' ) {
 function air_helper_helper_force_mail_to( $args ) {
   $to = apply_filters( 'air_helper_helper_mail_to', 'koodarit@dude.fi' );
 
-  if ( getenv( 'WP_ENV' ) === 'staging' ) {
+  if ( wp_get_environment_type() === 'staging' ) {
     $allowed_roles = apply_filters( 'air_helper_helper_mail_to_allowed_roles', [ 'administrator', 'editor', 'author' ] );
     $user = get_user_by( 'email', $args['to'] );
 

--- a/inc/media.php
+++ b/inc/media.php
@@ -5,7 +5,7 @@
  * @Author: Timi Wahalahti
  * @Date:   2020-01-10 16:42:40
  * @Last Modified by:   Timi Wahalahti
- * @Last Modified time: 2020-03-12 13:31:48
+ * @Last Modified time: 2021-02-19 14:26:46
  *
  * @package air-helper
  */
@@ -20,7 +20,7 @@
 if ( apply_filters( 'air_helper_change_uploads_path', true ) ) {
   $update_option = true;
 
-  if ( 'production' === getenv( 'WP_ENV' ) && get_option( 'air_helper_changed_uploads_path' ) ) {
+  if ( 'production' === wp_get_environment_type() && get_option( 'air_helper_changed_uploads_path' ) ) {
     $update_option = false;
   }
 

--- a/plugin-helpers.php
+++ b/plugin-helpers.php
@@ -5,7 +5,7 @@
  * @Author: Timi Wahalahti
  * @Date:   2020-01-10 14:36:38
  * @Last Modified by:   Timi Wahalahti
- * @Last Modified time: 2020-02-25 10:47:23
+ * @Last Modified time: 2021-02-19 14:26:47
  *
  * @package air-helper
  */
@@ -65,7 +65,7 @@ function air_helper_get_care_plan_hostnames() {
 function air_helper_site_has_care_plan() {
   $hostnames = air_helper_get_care_plan_hostnames();
 
-  if ( 'development' !== getenv( 'WP_ENV' ) && ! array_key_exists( php_uname( 'n' ), $hostnames ) ) {
+  if ( 'development' !== wp_get_environment_type() && ! array_key_exists( php_uname( 'n' ), $hostnames ) ) {
     return false;
   }
 


### PR DESCRIPTION
Changes all the uses cases of direct `WP_ENV` PHP environment variable to use WordPress core function `wp_get_environment_type` instead. That function was introduced in [core version 5.5](https://make.wordpress.org/core/2020/07/24/new-wp_get_environment_type-function-in-wordpress-5-5/) so this PR also bumps the plugins requires at least version to that.