### PR TITLE
Add helper function to output block content

### DIFF
--- a/air-helper.php
+++ b/air-helper.php
@@ -87,6 +87,7 @@ function air_helper_fly() {
   require_once air_helper_base_path() . '/inc/tinymce.php';
   require_once air_helper_base_path() . '/inc/media.php';
   require_once air_helper_base_path() . '/inc/misc.php';
+  require_once air_helper_base_path() . '/inc/custom-settings.php';
 } // end air_helper_fly
 
 /**

--- a/functions/custom-settings.php
+++ b/functions/custom-settings.php
@@ -4,8 +4,8 @@
  *
  * @Author: Timi Wahalahti
  * @Date:   2021-05-20 17:54:57
- * @Last Modified by:   Timi Wahalahti
- * @Last Modified time: 2021-05-20 18:27:59
+ * @Last Modified by: Niku Hietanen
+ * @Last Modified time: 2021-05-28 14:34:18
  *
  * @package air-helper
  */
@@ -68,3 +68,33 @@ if ( ! function_exists( 'get_custom_settings_post_id' ) ) {
     return $post_id;
   } // end get_custom_settings_post_id
 } // end if
+
+if ( ! function_exists( 'use_block_editor_in_custom_setting_group' ) ) {
+
+  /**
+   * Check if to use block editor in setting group post.
+   */
+  function use_block_editor_in_custom_setting_group( $post_id ) {
+    $setting_group_post_ids = apply_filters( 'air_helper_custom_settings_post_ids', [] );
+
+    if ( ! in_array( $post_id, $setting_group_post_ids, true ) ) {
+      return false;
+    }
+
+    $block_editor_prefix = apply_filters( 'air_helper_custom_settings_block_editor_prefix', 'block-editor/' );
+
+    $setting_group_post_ids_with_block_editor = array_filter(
+      $setting_group_post_ids,
+      function( $key ) use ( $block_editor_prefix ) {
+        return false !== strpos( $key, $block_editor_prefix );
+      },
+      ARRAY_FILTER_USE_KEY
+    );
+
+    if ( in_array( $post_id, $setting_group_post_ids_with_block_editor, true ) ) {
+      return true;
+    }
+
+    return false;
+  }
+}

--- a/functions/misc.php
+++ b/functions/misc.php
@@ -148,3 +148,41 @@ if ( ! function_exists( 'get_primary_category' ) ) {
     return false;
   } // end get_primary_category
 } // end if
+
+if ( ! function_exists( 'the_block_content' ) ) {
+  /**
+   * Outputs block content from a post
+   *
+   * @since  2.9.0
+   * @param int     $post_id Post id to get block content from.
+   * @param boolean $echo If true, echoes the block content otherwise returns.
+   * @return mixed
+   */
+  function the_block_content( $post_id, $echo = true ) {
+    if ( ! has_blocks( $post_id ) ) {
+      return;
+    }
+
+    /**
+     * Overwrite global post to make post related
+     * functions work inside block content
+     */
+    global $post;
+    $post = get_post( $post_id ); // phpcs:ignore
+    setup_postdata( $post );
+
+    // Do the block content
+    $block_content = apply_filters( 'the_content', get_the_content( '', '', $post ) );
+
+    wp_reset_postdata();
+
+    if ( ! $echo ) {
+      return $block_content;
+    }
+
+    /**
+     * Output blocks, already escaped on render function
+     */
+    echo $block_content; // phpcs:ignore
+  } // end the_block_content
+} // end if

--- a/inc/custom-settings.php
+++ b/inc/custom-settings.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Custom settings related
+ *
+ * @Author: Niku Hietanen
+ * @Date: 2021-05-28 14:16:00
+ * @Last Modified by: Niku Hietanen
+ * @Last Modified time: 2021-05-28 14:34:02
+ *
+ * @package air-helper
+ */
+
+/**
+ * Add post type support for editor depending on whether
+ * to use block editor in current setting group
+ *
+ * @since  2.9.0
+ */
+add_action( 'admin_init', 'air_helper_editor_support_for_setting_group_post', 99, 1 );
+function air_helper_editor_support_for_setting_group_post() {
+
+  // Try find out which post id we are loading in admin
+  $post_id = false;
+  if ( isset( $_GET['post'] ) ) { // phpcs:ignore
+    $post_id = intval( $_GET['post'] ); // phpcs:ignore
+  } elseif ( isset( $_POST['post_ID'] ) ) { // phpcs:ignore
+    $post_id = intval( $_POST['post_ID'] ); // phpcs:ignore
+  }
+
+  if ( ! $post_id ) {
+    return;
+  }
+
+  if ( use_block_editor_in_custom_setting_group( $post_id ) ) {
+    // Post type support 'editor' is needed for block editor
+    add_post_type_support( 'settings', 'editor' );
+  } else {
+    remove_post_type_support( 'settings', 'editor' );
+  }
+} // end air_helper_set_editor_type_for_setting_group_post
+
+/**
+ * Check whether to use classic or block editor
+ * for a certain post type as defined in the settings
+ */
+add_filter( 'use_block_editor_for_post', __NAMESPACE__ . '\air_helper_use_block_editor_in_custom_setting_group', 10, 2 );
+function air_helper_use_block_editor_in_custom_setting_group( $use_block_editor, $post ) {
+  $settings_post_types = apply_filters( 'air_helper_custom_settings_post_types', [ 'settings' ] );
+
+  // Use block editor if settings page is a block editor type
+  if ( in_array( $post->post_type, $settings_post_types, true ) ) {
+    return use_block_editor_in_custom_setting_group( $post->ID );
+  }
+  return $use_block_editor;
+} // end air_helper_use_block_editor_in_custom_setting_group


### PR DESCRIPTION
The function is intended for outputting block content outside the loop and context of actual post. Like for example when we are using setting groups or page-for-post-type to build extra blocks to show on archive pages after the actual archive content. 