### PR TITLE
Enable string translations inside a REST request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+- Support for REST requests to string translation functions
+
 ## [2.10.2] - 2021-08-04
 ### Fixed
 - Polylang support for custom setting group block editor checks

--- a/README.md
+++ b/README.md
@@ -68,6 +68,14 @@ add_filter( 'air_helper_pll_register_strings', function() {
 } );
 ```
 
+#### REST API support for string translations
+
+By default, the string translation functions like `ask__()` does not work as intended when run inside a REST request, because Polylang does not support it. You can enable support by setting a `lang` parameter to your REST request and enabling the feature with hook:
+
+```php
+add_filter( 'air_helper_pll_enable_rest', '__return_true' );
+```
+
 ### Image lazyloading
 
 Air-helper supports [tuupola/lazyload](https://github.com/tuupola/lazyload) (legacy) and [vanilla-lazyload](https://github.com/verlok/vanilla-lazyload) (current). [Air-light](https://github.com/digitoimistodude/air-light) version prior 6.1.8 (2020-10-20) had support for lazyload.js provided by [tuupola/lazyload](https://github.com/tuupola/lazyload) which is still legacy-supported by air-helper but no longer provided by [air-light](https://github.com/digitoimistodude/air-light) theme.

--- a/functions/localization.php
+++ b/functions/localization.php
@@ -21,6 +21,14 @@ function ask__( $key, $lang = null ) {
   $strings = apply_filters( 'air_helper_pll_register_strings', [] );
 
   if ( isset( $strings[ $key ] ) ) {
+    /**
+     * Check if this is a REST API request and try to get current lang from the get
+     * parameter because pll_get_current_language does not work inside a REST request
+     */
+    if ( apply_filters( 'air_helper_pll_enable_rest', false ) && defined( 'REST_REQUEST' ) && isset( $_GET['lang'] ) ) { // phpcs:ignore
+      $lang = sanitize_key( $_GET['lang'] ); // phpcs:ignore
+    }
+
     if ( null === $lang ) {
       return pll__( $strings[ $key ] );
     } else {


### PR DESCRIPTION
Some of the Polylang functionality, such as `pll_get_current_language()`does not work inside a REST request. This causes issues when we are running templates that uses `ask__()` functionality inside the requests so we can return a pre-rendered template in the REST response. 

PR introduces a feature to check if we are running a REST request and tries to get the `lang` parameter from `$_GET` data. Feature is disabled by default and can be enabled by returning true from `air_helper_pll_enable_rest` filter.