### PR TITLE
Fix regular expression for prefix removal hook

### DIFF
--- a/inc/archives.php
+++ b/inc/archives.php
@@ -21,7 +21,7 @@
  */
 add_filter( 'get_the_archive_title', 'air_helper_helper_remove_archive_title_prefix' );
 function air_helper_helper_remove_archive_title_prefix( $title ) {
-  return preg_replace( '/^\w+: /', '', $title );
+  return preg_replace( '#^[\w\d\s]+:\s*#', '', wp_strip_all_tags( $title ) );
 } // end air_helper_helper_remove_archive_title_prefix
 
 /**


### PR DESCRIPTION
This PR fixes regex for `air_helper_helper_remove_archive_title_prefix` hook. Tested working in real project.