### PR TITLE
Added after_air_helper_init action

### DIFF
--- a/air-helper.php
+++ b/air-helper.php
@@ -114,6 +114,8 @@ add_action( 'init', 'air_helper_admin_fly' );
   require_once air_helper_base_path() . '/inc/admin/updates.php';
   require_once air_helper_base_path() . '/inc/admin/helpscout.php';
   require_once air_helper_base_path() . '/inc/admin/polylang.php';
+
+  do_action( 'after_air_helper_init' );
 } // end air_helper_admin_fly
 
 /**


### PR DESCRIPTION
Adds a action to tell theme when air helper is activated (for example: for ask__)

Required by https://github.com/digitoimistodude/air-light/pull/201