### PR TITLE
Add array check to Gutenberg allowed block filter

### DIFF
--- a/inc/admin/gutenberg.php
+++ b/inc/admin/gutenberg.php
@@ -23,7 +23,7 @@
 add_filter( 'allowed_block_types_all', 'air_helper_gutenberg_allowed_blocks', 50 );
 function air_helper_gutenberg_allowed_blocks( $allowed_blocks ) {
   // After WP 6.1 you cannot add new list items without core/list-item block that was introduced
-  if ( in_array( 'core/list', $allowed_blocks ) ) {
+  if ( is_array( $allowed_blocks ) && in_array( 'core/list', $allowed_blocks ) ) {
     $allowed_blocks[] = 'core/list-item';
   }
 


### PR DESCRIPTION
This fixes the TypeError that will be thrown (and causing the page to show an internal error message), at least in PHP 8. Only happens if all blocks are allowed (allowed_blocks => 'all').

The filter [allowed_block_types_all](https://developer.wordpress.org/reference/hooks/allowed_block_types_all/) returns either an array or a boolean.