### PR TITLE
skip getting srcset for gifs (T-25654)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Unreleased
+
+* Skip getting srcset for gifs (T-25654)
+
 ### 3.2.5: 2025-02-17
 
 * Delete problematic tag mixup 2.0.0-beta, 1.0.3 to prevent packagist issues

--- a/functions/image-lazyload-native.php
+++ b/functions/image-lazyload-native.php
@@ -72,8 +72,15 @@ if ( ! function_exists( 'get_native_lazyload_tag' ) ) {
     // Get alt
     $alt = get_post_meta( $image_id, '_wp_attachment_image_alt', true );
 
+    // Attachment types to skip getting srcsets for
+    $attachment_types_to_skip = apply_filters( 'air_helper_attachment_types_to_skip_srcset_for', [ 'image/gif' ] );
+
     // Get srcset
-    $srcset = wp_get_attachment_image_srcset( $image_id );
+    $srcset = false;
+    if ( ! in_array( get_post_mime_type( $image_id ), $attachment_types_to_skip, true ) ) {
+      $srcset = wp_get_attachment_image_srcset( $image_id );
+    }
+
     $is_first_block = false;
 
     // If image is in the first block we want to add loading="eager" instead of lazy


### PR DESCRIPTION
https://height.app/sgr2jAyukJ/T-25654

Gifs don't work if they get srcset, so skip getting them for gifs.
Also adds a filter to add more mime types to skip getting srcsets for.